### PR TITLE
Fix errno clang issue

### DIFF
--- a/src/graph_io.cpp
+++ b/src/graph_io.cpp
@@ -1,3 +1,5 @@
+#include <gdsb/graph_io.h>
+
 #include <cstdlib>
 #include <limits>
 #include <stdexcept>

--- a/src/graph_io.cpp
+++ b/src/graph_io.cpp
@@ -4,6 +4,10 @@
 #include <limits>
 #include <stdexcept>
 
+#if !defined(__clang__)
+#include <cerrno>
+#endif
+
 namespace gdsb
 {
 
@@ -12,10 +16,12 @@ unsigned long read_ulong(char const* source, char** end)
     constexpr int numerical_base = 10;
     unsigned long const value = std::strtoul(source, end, numerical_base);
 
+#if !defined(__clang__)
     if (errno == ERANGE)
     {
         return std::numeric_limits<unsigned long>::max();
     }
+#endif
 
     return value;
 }


### PR DESCRIPTION
This PR addresses the issue where `errno` is not available for the clang compiler, as we have seen in the [simexpal build](https://github.com/hu-macsy/simexpal/actions/runs/10077482302/job/27860104011?pr=177). 

Therefore, if we compile on clang we don't use the `errno` functionality.

A similar issue [on stackoverflow](https://stackoverflow.com/questions/24206989/error-use-of-undeclared-identifier-errno-t).