### PR TITLE
Insert Return Edges for Undirected Graphs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,9 @@ target_sources(gdsb
     src/experiment.cpp
 )
 
+find_package(OpenMP)
+target_link_libraries(gdsb INTERFACE OpenMP::OpenMP_CXX)
+
 set_property(TARGET gdsb PROPERTY POSITION_INDEPENDENT_CODE ON)
 
 # Set this option if you want to use the MPI facilities of GDSB 

--- a/include/gdsb/graph_input.h
+++ b/include/gdsb/graph_input.h
@@ -387,16 +387,17 @@ template <typename CopyF, typename Edges> void insert_return_edges(CopyF&& copy_
     // Each thread will copy a dedicated range of the read in edges.
 #pragma omp parallel
     {
-        size_t const edge_begin = edge_offset(original_size, omp_get_thread_num(), omp_get_num_threads());
-        size_t const edge_end = edge_begin + partition_edge_count(original_size, omp_get_thread_num(), omp_get_num_threads());
+        size_t const edge_begin_offset = edge_offset(original_size, omp_get_thread_num(), omp_get_num_threads());
+        size_t const edge_end_offset =
+            edge_begin_offset + partition_edge_count(original_size, omp_get_thread_num(), omp_get_num_threads());
 
         auto original_it = std::begin(edges);
-        std::advance(original_it, edge_begin);
+        std::advance(original_it, edge_begin_offset);
         auto original_end_it = std::begin(edges);
-        std::advance(original_end_it, edge_end);
+        std::advance(original_end_it, edge_end_offset);
 
-        size_t const copy_begin = original_size + edge_begin;
-        size_t const copy_end = original_size + edge_end;
+        size_t const copy_begin = original_size + edge_begin_offset;
+        size_t const copy_end = original_size + edge_end_offset;
 
         auto copy_it = std::begin(edges);
         std::advance(copy_it, copy_begin);

--- a/include/gdsb/graph_input.h
+++ b/include/gdsb/graph_input.h
@@ -3,6 +3,8 @@
 #include <gdsb/graph.h>
 #include <gdsb/graph_io_parameters.h>
 
+#include <omp.h>
+
 #include <cassert>
 #include <cstring>
 #include <filesystem>
@@ -374,6 +376,37 @@ template <typename Vertex, typename F> void read_graph_idx(std::istream& ins, F&
         emplace(i, idx);
 
         ++i;
+    }
+}
+
+template <typename CopyF, typename Edges> void insert_return_edges(CopyF&& copy_f, Edges& edges)
+{
+    size_t const original_size = edges.size();
+    edges.resize(original_size * 2);
+
+    // Each thread will copy a dedicated range of the read in edges.
+#pragma omp parallel
+    {
+        size_t const edge_begin = edge_offset(original_size, omp_get_thread_num(), omp_get_num_threads());
+        size_t const edge_end = edge_begin + partition_edge_count(original_size, omp_get_thread_num(), omp_get_num_threads());
+
+        auto original_it = std::begin(edges);
+        std::advance(original_it, edge_begin);
+        auto original_end_it = std::begin(edges);
+        std::advance(original_end_it, edge_end);
+
+        size_t const copy_begin = original_size + edge_begin;
+        size_t const copy_end = original_size + edge_end;
+
+        auto copy_it = std::begin(edges);
+        std::advance(copy_it, copy_begin);
+        auto copy_end_it = std::begin(edges);
+        std::advance(copy_end_it, copy_end);
+
+        for (; original_it < original_end_it && copy_it < copy_end_it; ++original_it, ++copy_it)
+        {
+            copy_f(*original_it, *copy_it);
+        }
     }
 }
 

--- a/test/graph_input_tests.cpp
+++ b/test/graph_input_tests.cpp
@@ -729,21 +729,6 @@ TEST_CASE("insert_return_edges")
         insert_return_edges(std::move(copy_f), edges);
 
         REQUIRE((original_edge_size * 2) == edges.size());
-        REQUIRE(no_duplicates_found());
-
-        bool all_return_edges_found = true;
-        auto original_begin = std::begin(edges);
-        auto original_end = std::begin(edges);
-        std::advance(original_end, original_edge_size);
-
-        for (auto it = original_begin; it != original_end && all_return_edges_found; ++it)
-        {
-            auto found_it =
-                std::find_if(original_end, std::end(edges),
-                             [&](Edge32 const& e) { return e.source == it->target && e.target == it->source; });
-            all_return_edges_found = found_it != std::end(edges);
-        }
-
-        CHECK(all_return_edges_found);
+        CHECK(no_duplicates_found());
     }
 }

--- a/test/graph_input_tests.cpp
+++ b/test/graph_input_tests.cpp
@@ -712,11 +712,6 @@ TEST_CASE("insert_return_edges")
                                  [&](Edge32 const& d) { return e->source == d.source && e->target == d.target; });
 
                 no_duplicates = duplicate == std::end(edges);
-
-                if (!no_duplicates)
-                {
-                    std::cout << "{" << e->source << ", " << e->target << "}" << std::endl;
-                }
             }
             return no_duplicates;
         };

--- a/test/graph_input_tests.cpp
+++ b/test/graph_input_tests.cpp
@@ -647,16 +647,17 @@ TEST_CASE("read_binary_graph_partition, small weighted temporal, partition id 1,
 
 TEST_CASE("insert_return_edges")
 {
-    SECTION("unweighted edges")
+    SECTION("unweighted edges, all return edges exist")
     {
         Edges32 edges;
         auto emplace = [&](Vertex32 u, Vertex32 v) { edges.push_back(Edge32{ u, v }); };
 
-        std::ifstream graph_input_unweighted_directed(graph_path + unweighted_directed_graph_enzymes);
+        std::ifstream graph_input_unweighted_directed(graph_path + undirected_unweighted_soc_dolphins);
 
+        // intentionally reading graph as directed
         auto const [vertex_count, edge_count] =
-            read_graph<Vertex32, decltype(emplace), EdgeListDirectedUnweightedStatic>(graph_input_unweighted_directed,
-                                                                                      std::move(emplace));
+            read_graph<Vertex32, decltype(emplace), MatrixMarketDirectedUnweightedStatic>(graph_input_unweighted_directed,
+                                                                                          std::move(emplace));
 
         size_t const original_edge_size = edges.size();
 
@@ -669,6 +670,71 @@ TEST_CASE("insert_return_edges")
         insert_return_edges(std::move(copy_f), edges);
 
         REQUIRE((original_edge_size * 2) == edges.size());
+
+        bool all_return_edges_found = true;
+        auto original_begin = std::begin(edges);
+        auto original_end = std::begin(edges);
+        std::advance(original_end, original_edge_size);
+
+        for (auto it = original_begin; it != original_end && all_return_edges_found; ++it)
+        {
+            auto found_it =
+                std::find_if(original_end, std::end(edges),
+                             [&](Edge32 const& e) { return e.source == it->target && e.target == it->source; });
+            all_return_edges_found = found_it != std::end(edges);
+        }
+
+        CHECK(all_return_edges_found);
+    }
+
+    SECTION("unweighted edges, no duplications")
+    {
+        Edges32 edges;
+        auto emplace = [&](Vertex32 u, Vertex32 v) { edges.push_back(Edge32{ u, v }); };
+
+        std::ifstream graph_input_unweighted_directed(graph_path + undirected_unweighted_soc_dolphins);
+
+        // intentionally reading graph as directed
+        auto const [vertex_count, edge_count] =
+            read_graph<Vertex32, decltype(emplace), MatrixMarketDirectedUnweightedStatic>(graph_input_unweighted_directed,
+                                                                                          std::move(emplace));
+
+        REQUIRE(edges.size() == 159u);
+
+        auto no_duplicates_found = [&]() -> bool
+        {
+            bool no_duplicates = true;
+            for (auto e = std::begin(edges); e != std::end(edges) & no_duplicates; ++e)
+            {
+                auto next = std::next(e);
+                auto duplicate =
+                    std::find_if(next, std::end(edges),
+                                 [&](Edge32 const& d) { return e->source == d.source && e->target == d.target; });
+
+                no_duplicates = duplicate == std::end(edges);
+
+                if (!no_duplicates)
+                {
+                    std::cout << "{" << e->source << ", " << e->target << "}" << std::endl;
+                }
+            }
+            return no_duplicates;
+        };
+
+        REQUIRE(no_duplicates_found());
+
+        size_t const original_edge_size = edges.size();
+
+        auto copy_f = [](Edge32& original, Edge32& copy)
+        {
+            copy.source = original.target;
+            copy.target = original.source;
+        };
+
+        insert_return_edges(std::move(copy_f), edges);
+
+        REQUIRE((original_edge_size * 2) == edges.size());
+        REQUIRE(no_duplicates_found());
 
         bool all_return_edges_found = true;
         auto original_begin = std::begin(edges);


### PR DESCRIPTION
When reading a binary graph file, or a directed graph file that shall be converted to an undirected graph, the function `insert_return_edges()` will insert the return edges: edge `{u, v}` will be copied and inserted as `{v, u}`. 

A simple test making sure all edges have been copied and converted to a return edge is included.