### PR TITLE
Graph Output Test: Additional Checks

### DIFF
--- a/test/graph_output_tests.cpp
+++ b/test/graph_output_tests.cpp
@@ -11,10 +11,12 @@
 #include <filesystem>
 #include <fstream>
 
+using namespace gdsb;
+
 TEST_CASE("open_binary_file")
 {
     std::filesystem::path file_path{ graph_path + "write_test.gdsb" };
-    std::ofstream out_file = gdsb::open_binary_file(file_path);
+    std::ofstream out_file = open_binary_file(file_path);
     CHECK(out_file.is_open());
     CHECK(out_file.good());
 
@@ -25,32 +27,65 @@ TEST_CASE("open_binary_file")
 TEST_CASE("write_graph, enzymes, binary")
 {
     // First we read in a test graph
-    gdsb::Edges32 edges;
-    auto emplace = [&](gdsb::Vertex32 u, gdsb::Vertex32 v) { edges.push_back(gdsb::Edge32{ u, v }); };
+    Edges32 edges;
+    auto emplace = [&](Vertex32 u, Vertex32 v) { edges.push_back(Edge32{ u, v }); };
     std::ifstream graph_input_unweighted_directed(graph_path + unweighted_directed_graph_enzymes);
     auto const [vertex_count, edge_count] =
-        gdsb::read_graph<gdsb::Vertex32, decltype(emplace), gdsb::EdgeListDirectedUnweightedStatic>(graph_input_unweighted_directed,
-                                                                                                    std::move(emplace));
+        read_graph<Vertex32, decltype(emplace), EdgeListDirectedUnweightedStatic>(graph_input_unweighted_directed,
+                                                                                  std::move(emplace));
 
-    CHECK(edges.size() == 168);
+    size_t constexpr expected_edge_count = 168u;
+    CHECK(edges.size() == expected_edge_count);
 
     // In case of developing a new format: use this line to produce the new test graph.
     // std::filesystem::path file_path{ graph_path + "ENZYMES_g1.bin" };
 
     std::filesystem::path file_path{ graph_path + "test_graph.bin" };
 
-    std::ofstream out_file = gdsb::open_binary_file(file_path);
+    std::ofstream out_file = open_binary_file(file_path);
 
     REQUIRE(out_file);
 
     // Write Graph
-    gdsb::write_graph<gdsb::BinaryDirectedUnweightedStatic, gdsb::Vertex32, gdsb::Weight>(
-        out_file, edges, vertex_count, edge_count,
-        [](std::ofstream& o, auto edge)
-        {
-            o.write(reinterpret_cast<const char*>(&edge.source), sizeof(edge.source));
-            o.write(reinterpret_cast<const char*>(&edge.target), sizeof(edge.target));
-        });
+    write_graph<BinaryDirectedUnweightedStatic, Vertex32, Weight>(out_file, edges, vertex_count, edge_count,
+                                                                  [](std::ofstream& o, auto edge)
+                                                                  {
+                                                                      o.write(reinterpret_cast<const char*>(&edge.source),
+                                                                              sizeof(edge.source));
+                                                                      o.write(reinterpret_cast<const char*>(&edge.target),
+                                                                              sizeof(edge.target));
+                                                                  });
+
+    // Now we read in the written graph and check if we read the expected data.
+    std::ifstream binary_graph(file_path);
+
+    BinaryGraphHeaderMetaDataV2 header = read_binary_graph_header(binary_graph);
+    REQUIRE(header.vertex_id_byte_size == sizeof(Vertex32));
+    REQUIRE(header.weight_byte_size == sizeof(Weight));
+
+    Edges32 edges_in;
+    auto read_f = [&](std::ifstream& input)
+    {
+        edges_in.push_back(Edge32{});
+        input.read((char*)&edges_in.back().source, sizeof(Vertex32));
+        input.read((char*)&edges_in.back().target, sizeof(Vertex32));
+        return true;
+    };
+
+    auto [vertex_count_in, edge_count_in] = read_binary_graph(binary_graph, header, std::move(read_f));
+
+    // Note: EOF is an int (for most OS?)
+    int eof_marker;
+    binary_graph.read(reinterpret_cast<char*>(&eof_marker), sizeof(decltype(eof_marker)));
+    REQUIRE(binary_graph.eof());
+
+    CHECK(vertex_count_in == 38u);
+    CHECK(edge_count_in == expected_edge_count);
+    REQUIRE(edges_in.size() == edge_count_in);
+
+    bool edge_25_to_2_exists = std::any_of(std::begin(edges_in), std::end(edges_in),
+                                           [](Edge32 const& edge) { return edge.source == 25 && edge.target == 2; });
+    CHECK(edge_25_to_2_exists);
 
     // In case of developing a new format: comment this line
     REQUIRE(std::remove(file_path.c_str()) == 0);
@@ -59,36 +94,88 @@ TEST_CASE("write_graph, enzymes, binary")
 TEST_CASE("write_graph, small weighted temporal, binary")
 {
     // First we read in a test graph
-    gdsb::WeightedTimestampedEdges32 timestamped_edges;
-    auto emplace = [&](gdsb::Vertex32 u, gdsb::Vertex32 v, gdsb::Weight w, gdsb::Timestamp32 t) {
+    WeightedTimestampedEdges32 timestamped_edges;
+    auto emplace = [&](Vertex32 u, Vertex32 v, Weight w, Timestamp32 t) {
         timestamped_edges.push_back({ { u, { v, w } }, t });
     };
 
     std::ifstream graph_input_small_temporal(graph_path + small_weighted_temporal_graph);
     auto const [vertex_count, edge_count] =
-        gdsb::read_graph<gdsb::Vertex32, decltype(emplace), gdsb::EdgeListDirectedWeightedDynamic>(graph_input_small_temporal,
-                                                                                                   std::move(emplace));
+        read_graph<Vertex32, decltype(emplace), EdgeListDirectedWeightedDynamic>(graph_input_small_temporal, std::move(emplace));
 
-    CHECK(timestamped_edges.size() == 7);
+    size_t constexpr expected_edge_count = 7u;
+    REQUIRE(expected_edge_count == timestamped_edges.size());
+    CHECK(expected_edge_count == edge_count);
 
     // In case of developing a new format: use this line to produce the new test graph.
     // std::filesystem::path file_path{ graph_path + "small_graph_temporal.bin" };
 
-    std::filesystem::path file_path{ graph_path + "small_graph_temporal_test_graph.bin" };
-    std::ofstream out_file = gdsb::open_binary_file(file_path);
-
+    std::filesystem::path const file_path{ graph_path + "small_graph_temporal_test_graph.bin" };
+    std::ofstream out_file = open_binary_file(file_path);
     REQUIRE(out_file);
 
     // Write Graph
-    gdsb::write_graph<gdsb::BinaryDirectedWeightedDynamic, gdsb::Vertex32, gdsb::Weight>(
+    write_graph<BinaryDirectedWeightedDynamic, Vertex32, Weight>(
         out_file, timestamped_edges, vertex_count, edge_count,
         [](std::ofstream& o, auto edge)
         {
-            o.write(reinterpret_cast<const char*>(&edge.edge.source), sizeof(int32_t));
-            o.write(reinterpret_cast<const char*>(&edge.edge.target.vertex), sizeof(int32_t));
+            o.write(reinterpret_cast<const char*>(&edge.edge.source), sizeof(Vertex32));
+            o.write(reinterpret_cast<const char*>(&edge.edge.target.vertex), sizeof(Vertex32));
             o.write(reinterpret_cast<const char*>(&edge.edge.target.weight), sizeof(float));
-            o.write(reinterpret_cast<const char*>(&edge.timestamp), sizeof(int32_t));
+            o.write(reinterpret_cast<const char*>(&edge.timestamp), sizeof(Vertex32));
         });
+
+    std::ifstream binary_graph(file_path);
+
+    BinaryGraphHeaderMetaDataV2 header = read_binary_graph_header(binary_graph);
+    REQUIRE(header.vertex_id_byte_size == sizeof(Vertex32));
+    REQUIRE(header.weight_byte_size == sizeof(Weight));
+
+    WeightedTimestampedEdges32 timestamped_edges_in;
+    auto read_f = [&](std::ifstream& input)
+    {
+        timestamped_edges_in.push_back({});
+
+        input.read((char*)&timestamped_edges_in.back().edge.source, sizeof(Vertex32));
+        input.read((char*)&timestamped_edges_in.back().edge.target.vertex, sizeof(Vertex32));
+        input.read((char*)&timestamped_edges_in.back().edge.target.weight, sizeof(Weight));
+        input.read((char*)&timestamped_edges_in.back().timestamp, sizeof(Timestamp32));
+        return true;
+    };
+
+    auto const [vertex_count_in, edge_count_in] = read_binary_graph(binary_graph, header, std::move(read_f));
+    REQUIRE(vertex_count_in == 7);
+    REQUIRE(edge_count_in == expected_edge_count);
+
+    CHECK(!binary_graph.eof());
+
+    // File content:
+    // 0 1 1 1
+    // 2 3 1 3
+    // 1 2 1 2
+    // 1 4 1 8
+    // 3 4 1 4
+    // 3 5 1 6
+    // 3 6 1 7
+
+    size_t idx = 0;
+    REQUIRE(timestamped_edges_in.size() == edge_count_in);
+    CHECK(timestamped_edges_in[idx].edge.source == 0);
+    CHECK(timestamped_edges_in[idx].edge.target.vertex == 1);
+    CHECK(timestamped_edges_in[idx].edge.target.weight == 1.f);
+    CHECK(timestamped_edges_in[idx].timestamp == 1);
+
+    ++idx;
+    CHECK(timestamped_edges_in[idx].edge.source == 2);
+    CHECK(timestamped_edges_in[idx].edge.target.vertex == 3);
+    CHECK(timestamped_edges_in[idx].edge.target.weight == 1.f);
+    CHECK(timestamped_edges_in[idx].timestamp == 3);
+
+    ++idx;
+    CHECK(timestamped_edges_in[idx].edge.source == 1);
+    CHECK(timestamped_edges_in[idx].edge.target.vertex == 2);
+    CHECK(timestamped_edges_in[idx].edge.target.weight == 1.f);
+    CHECK(timestamped_edges_in[idx].timestamp == 2);
 
     // In case of developing a new format: comment this line
     REQUIRE(std::remove(file_path.c_str()) == 0);


### PR DESCRIPTION
Originally, in the graph output we write a graph to file and simply check for success of the write routine. The graph input tests make sure that an already stored binary graph contains the correct and expected data. In order to remove any issues with changing routines that are used within the binary graph writing procedure and therefore introducing a bug we do now check that the written graph during the tests is written as expected.