### PR TITLE
AppleClang support: fix openmp and add to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,8 @@ jobs:
           ninja
           ./gdsb_mpi_test
 
-  macos-build-latest-with-clang:
-    name: "macOS clang"
+  macos-build-latest-with-llvm-clang:
+    name: "macOS llvm clang"
     runs-on: macos-14
     steps:
       - name: Install prerequisites
@@ -54,5 +54,27 @@ jobs:
           [ ! -d build ] && mkdir build
           cd build
           cmake -DGDSB_MPI=OFF -DGDSB_TEST=ON -DCMAKE_CXX_COMPILER=/opt/homebrew/opt/llvm/bin/clang++ -DCMAKE_C_COMPILER=/opt/homebrew/opt/llvm/bin/clang -GNinja ..
+          ninja
+          ./gdsb_test
+
+  macos-build-latest-with-apple-clang:
+    name: "macOS AppleClang"
+    runs-on: macos-14
+    steps:
+      - name: Install prerequisites
+        run: |
+          brew install ninja
+          brew install libomp
+  
+      - name: Checkout gdsb
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+      
+      - name: build library and run tests (no MPI functionality)
+        run:  | 
+          [ ! -d build ] && mkdir build
+          cd build
+          cmake -DGDSB_MPI=OFF -DGDSB_TEST=ON -GNinja ..
           ninja
           ./gdsb_test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Set minimum version of CMake.
-cmake_minimum_required(VERSION 3.11.4)
+cmake_minimum_required(VERSION 3.14)
 
 # Set project name and version
 project(gdsb VERSION 0.2.0 LANGUAGES CXX)
@@ -71,7 +71,8 @@ if(NOT OpenMP_FOUND)
   # After setting basic OpenMP-folders, run find_package again to set everything. Also acts as a final sanity check.
   find_package(OpenMP REQUIRED)
 endif()
-target_link_libraries(gdsb INTERFACE OpenMP::OpenMP_CXX)
+
+target_link_libraries(gdsb PUBLIC OpenMP::OpenMP_CXX)
 
 set_property(TARGET gdsb PROPERTY POSITION_INDEPENDENT_CODE ON)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 cmake_minimum_required(VERSION 3.11.4)
 
 # Set project name and version
-project(gdsb VERSION 0.2.0)
+project(gdsb VERSION 0.2.0 LANGUAGES CXX)
 
 include(GNUInstallDirs)
 
@@ -31,6 +31,46 @@ target_sources(gdsb
 )
 
 find_package(OpenMP)
+
+# Thanks to NetworKit for the following OpenMP code looking or OpenMP in the
+# most common folders:
+# https://github.com/networkit/networkit/blob/master/CMakeLists.txt#L145
+if(NOT OpenMP_FOUND)
+  if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang")
+    # This will find default libomp-installations for homebrew/MacPorts
+    find_library(LIBOMP_PATH NAMES omp PATHS "/usr/local/opt/libomp/lib" "/opt/local/lib/libomp" "/opt/homebrew/opt/libomp/lib")
+    find_path(LIBOMP_INCLUDE NAMES omp.h PATHS "/usr/local/opt/libomp/include" "/opt/local/include/libomp" "/opt/homebrew/opt/libomp/include")
+
+    if(LIBOMP_PATH AND LIBOMP_INCLUDE)
+      set(OpenMP_CXX_FLAGS "-Xpreprocessor -fopenmp -I${LIBOMP_INCLUDE}" CACHE STRING "Manually set" FORCE)
+    endif()
+  elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+    if(DEFINED ENV{CONDA_PREFIX})
+      find_library(LIBOMP_PATH NAMES omp HINTS "$ENV{CONDA_PREFIX}/lib"
+        PATHS "/usr/lib" "/usr/lib64")
+      find_path(LIBOMP_INCLUDE NAMES omp.h HINTS "$ENV{CONDA_PREFIX}/include"
+        PATHS "/usr/include")
+    else()
+      find_library(LIBOMP_PATH NAMES omp PATHS "/usr/lib" "/usr/lib64")
+      find_path(LIBOMP_INCLUDE NAMES omp.h PATHS "/usr/include")
+    endif()
+
+    if(LIBOMP_PATH AND LIBOMP_INCLUDE)
+      set(OpenMP_CXX_FLAGS "-fopenmp -I${LIBOMP_INCLUDE}" CACHE STRING "Manually set" FORCE)
+    endif()
+  endif()
+
+  # Set OpenMP-folders in case they are found with the aid of additional hints
+  if(LIBOMP_PATH AND LIBOMP_INCLUDE)
+    set(OpenMP_CXX_LIB_NAMES "omp" CACHE STRING "Manually set" FORCE)
+    set(OpenMP_omp_LIBRARY "${LIBOMP_PATH}" CACHE STRING "Manually set" FORCE)
+  else()
+    message(FATAL_ERROR "libomp was not found, but necessary to configure DHB with ${CMAKE_CXX_COMPILER_ID}")
+  endif()
+
+  # After setting basic OpenMP-folders, run find_package again to set everything. Also acts as a final sanity check.
+  find_package(OpenMP REQUIRED)
+endif()
 target_link_libraries(gdsb INTERFACE OpenMP::OpenMP_CXX)
 
 set_property(TARGET gdsb PROPERTY POSITION_INDEPENDENT_CODE ON)


### PR DESCRIPTION
CI now runs tests with ubuntu-gcc, mac-llvm-clang, mac-AppleClang.
Added code to find openmp for AppleClang on arm systems.