### PR TITLE
MPI File Read: Revision

### DIFF
--- a/include/gdsb/mpi_graph_io.h
+++ b/include/gdsb/mpi_graph_io.h
@@ -61,8 +61,7 @@ inline BinaryGraphHeader read_binary_graph_header(MPI_File const input)
     }
 }
 
-template <typename ReadF>
-bool read_binary_graph(MPI_File const input, BinaryGraphHeaderMetaDataV3 const& header, ReadF&& read)
+template <typename ReadF> bool read_binary_graph(MPI_File const input, BinaryGraphHeader const& header, ReadF&& read)
 {
     bool continue_reading = true;
     for (uint64_t e = 0; e < header.edge_count && continue_reading; ++e)

--- a/include/gdsb/mpi_graph_io.h
+++ b/include/gdsb/mpi_graph_io.h
@@ -61,19 +61,17 @@ inline BinaryGraphHeader read_binary_graph_header(MPI_File const input)
     }
 }
 
-template <typename ReadF> std::tuple<Vertex64, uint64_t> read_binary_graph(MPI_File const input, ReadF&& read)
+template <typename ReadF>
+bool read_binary_graph(MPI_File const input, BinaryGraphHeaderMetaDataV3 const& header, ReadF&& read)
 {
-    BinaryGraphHeader const data = read_binary_graph_header(input);
-
     bool continue_reading = true;
-    for (uint64_t e = 0; e < data.edge_count && continue_reading; ++e)
+    for (uint64_t e = 0; e < header.edge_count && continue_reading; ++e)
     {
         continue_reading = read(input);
     }
 
-    return std::make_tuple(data.vertex_count, data.edge_count);
+    return continue_reading;
 }
-
 
 template <typename ReadF>
 std::tuple<Vertex64, uint64_t> read_binary_graph_partition(MPI_File const input,

--- a/test/mpi_graph_io_tests.cpp
+++ b/test/mpi_graph_io_tests.cpp
@@ -95,7 +95,7 @@ TEST_CASE("MPI, Read Small Weighted Temporal Binary File")
     std::filesystem::path file_path(graph_path + small_weighted_temporal_graph_bin);
     mpi::FileWrapper input{ file_path };
 
-    BinaryGraphHeaderMetaDataV3 header = mpi::read_binary_graph_header(input.get());
+    BinaryGraphHeader header = mpi::read_binary_graph_header(input.get());
     bool const read_ok = mpi::read_binary_graph(input.get(), header, std::move(read_f));
     REQUIRE(read_ok);
 
@@ -187,7 +187,7 @@ TEST_CASE("MPI, read_binary_graph, undirected, unweighted, static")
     std::filesystem::path file_path(graph_path + unweighted_directed_graph_enzymes_bin);
     mpi::FileWrapper binary_graph{ file_path };
 
-    BinaryGraphHeaderMetaDataV3 header = mpi::read_binary_graph_header(binary_graph.get());
+    BinaryGraphHeader header = mpi::read_binary_graph_header(binary_graph.get());
     bool reading_ok = mpi::read_binary_graph(binary_graph.get(), header, std::move(read_f));
     REQUIRE(reading_ok);
 

--- a/test/mpi_graph_io_tests.cpp
+++ b/test/mpi_graph_io_tests.cpp
@@ -95,9 +95,12 @@ TEST_CASE("MPI, Read Small Weighted Temporal Binary File")
     std::filesystem::path file_path(graph_path + small_weighted_temporal_graph_bin);
     mpi::FileWrapper input{ file_path };
 
-    auto const [vertex_count, edge_count] = mpi::read_binary_graph(input.get(), std::move(read_f));
-    REQUIRE(vertex_count == 7);
-    REQUIRE(edge_count == 7);
+    BinaryGraphHeaderMetaDataV3 header = mpi::read_binary_graph_header(input.get());
+    bool const read_ok = mpi::read_binary_graph(input.get(), header, std::move(read_f));
+    REQUIRE(read_ok);
+
+    REQUIRE(header.vertex_count == 7);
+    REQUIRE(header.edge_count == 7);
 
     // Note: EOF is an int (for most OS?)
     // int eof_marker;
@@ -120,7 +123,7 @@ TEST_CASE("MPI, Read Small Weighted Temporal Binary File")
     // 3 6 1 7
 
     size_t idx = 0;
-    REQUIRE(timestamped_edges.size() == edge_count);
+    REQUIRE(timestamped_edges.size() == header.edge_count);
     CHECK(timestamped_edges[idx].edge.source == 0);
     CHECK(timestamped_edges[idx].edge.target.vertex == 1);
     CHECK(timestamped_edges[idx].edge.target.weight == 1.f);
@@ -184,11 +187,13 @@ TEST_CASE("MPI, read_binary_graph, undirected, unweighted, static")
     std::filesystem::path file_path(graph_path + unweighted_directed_graph_enzymes_bin);
     mpi::FileWrapper binary_graph{ file_path };
 
-    auto const [vertex_count, edge_count] = mpi::read_binary_graph(binary_graph.get(), std::move(read_f));
+    BinaryGraphHeaderMetaDataV3 header = mpi::read_binary_graph_header(binary_graph.get());
+    bool reading_ok = mpi::read_binary_graph(binary_graph.get(), header, std::move(read_f));
+    REQUIRE(reading_ok);
 
-    CHECK(vertex_count == 38);
-    CHECK(edge_count == 168);
-    REQUIRE(edges.size() == edge_count);
+    CHECK(header.vertex_count == 38);
+    CHECK(header.edge_count == 168);
+    REQUIRE(edges.size() == header.edge_count);
 
     // TODO: The counterpart of reading this graph file using regular C++ file
     // I/O routines is capable to read the EOF symbol at the end of the file.


### PR DESCRIPTION
This removes the dependency of reading in the header within the read_binary_graph() function.